### PR TITLE
feat: enable FIPS compliance

### DIFF
--- a/Containerfile.authorino
+++ b/Containerfile.authorino
@@ -11,7 +11,7 @@ ARG git_sha
 ENV git_sha=${git_sha:-unknown}
 ARG dirty
 ENV dirty=${dirty:-unknown}
-RUN CGO_ENABLED=0 GO111MODULE=on go build -a -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /usr/bin/authorino main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GO111MODULE=on go build -a -tags strictfipsruntime -ldflags "-X main.version=${version} -X main.gitSHA=${git_sha} -X main.dirty=${dirty}" -o /usr/bin/authorino main.go
 
 FROM registry.redhat.io/ubi9-minimal:latest
 


### PR DESCRIPTION
## Summary

Enable `CGO_ENABLED=1` and `GOEXPERIMENT=strictfipsruntime` in the product Containerfile so binaries dynamically link against the FIPS-validated OpenSSL provided by `ubi9/go-toolset`, satisfying the RHOAI "Designed for FIPS" requirement.

## Motivation

RHOAI requires all components to be "Designed for FIPS". The current images fail `check-payload` with `go binary is not CGO_ENABLED`. This change fixes the build flags.

## Validation

Image was built locally with these flags and scanned with `check-payload` — **Successful run**.

## Review

Only the `go build` line changes: `CGO_ENABLED=0` → `CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime` plus `-tags strictfipsruntime`.

## Test plan

- [ ] Konflux PR build passes
- [ ] check-payload reports `Successful run`